### PR TITLE
Update GitHub Actions workflow for NDK r27c and caching improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
     env:
       CC_aarch64-linux-android: /home/runner/android-ndk-r26c/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android31-clang
       AR_aarch64-linux-android: /home/runner/android-ndk-r26c/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
-      BASE_URL: ${{ github.event.repository.name == 'mbf-nightly' && '/mbf-nightly' || '/' }}
+      BASE_URL: './'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with: 
+        with:
           target: aarch64-linux-android
       - uses: mskelton/setup-yarn@v1
         with:
@@ -33,7 +33,7 @@ jobs:
       - name: Download NDK
         run: wget https://dl.google.com/android/repository/android-ndk-r26c-linux.zip -q -O ndk.zip
       - name: Extract NDK
-        run: unzip ndk.zip -d /home/runner/ 
+        run: unzip ndk.zip -d /home/runner/
       - name: Create cargo config
         run: |
           echo '[target.aarch64-linux-android]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
     name: Build and deploy site
     runs-on: ubuntu-latest
     env:
-      CC_aarch64-linux-android: /home/runner/android-ndk-r26c/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android31-clang
-      AR_aarch64-linux-android: /home/runner/android-ndk-r26c/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
+      CC_aarch64-linux-android: /home/runner/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android31-clang
+      AR_aarch64-linux-android: /home/runner/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
       BASE_URL: './'
     environment:
       name: github-pages
@@ -58,13 +58,13 @@ jobs:
         id: ndk_cache
         uses: actions/cache@v4
         with:
-          path: ~/android-ndk-r26c
-          key: linux-android-ndk-r26c
+          path: ~/android-ndk-r27c
+          key: linux-android-ndk-r27c
 
       - name: Install NDK
         if: steps.agent_cache.outputs.cache-hit != 'true' && steps.ndk_cache.outputs.cache-hit != 'true'
         run: |
-          curl -L "https://dl.google.com/android/repository/android-ndk-r26c-linux.zip" -o ndk.zip
+          curl -L "https://dl.google.com/android/repository/android-ndk-r27c-linux.zip" -o ndk.zip
           unzip ndk.zip -d /home/runner/
           rm ndk.zip
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,36 +24,111 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Agent Hash
+        id: agent_hash
+        run: |
+          echo "hash=$(find Cargo.* mbf-agent* mbf-res-man mbf-zip  -type f -exec md5sum {} \; | md5sum - | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Agent Cache
+        id: agent_cache
+        uses: actions/cache@v4
+        with:
+          key: mbf-agent-${{ steps.agent_hash.outputs.hash }}
+          path: |
+            ./mbf-site/src/agent_manifest.ts
+            ./mbf-site/public/mbf-agent
+
+      - name: Rust target cache
+        if: steps.agent_cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          key: rust-target-${{ steps.agent_hash.outputs.hash }}
+          restore-keys: rust-target-
+          path: |
+            ./target
+
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        if: steps.agent_cache.outputs.cache-hit != 'true'
         with:
           target: aarch64-linux-android
-      - uses: mskelton/setup-yarn@v1
+
+      - name: NDK Cache
+        if: steps.agent_cache.outputs.cache-hit != 'true'
+        id: ndk_cache
+        uses: actions/cache@v4
         with:
-          node-version: '20.x'
-      - name: Download NDK
-        run: wget https://dl.google.com/android/repository/android-ndk-r26c-linux.zip -q -O ndk.zip
-      - name: Extract NDK
-        run: unzip ndk.zip -d /home/runner/
+          path: ~/android-ndk-r26c
+          key: linux-android-ndk-r26c
+
+      - name: Install NDK
+        if: steps.agent_cache.outputs.cache-hit != 'true' && steps.ndk_cache.outputs.cache-hit != 'true'
+        run: |
+          curl -L "https://dl.google.com/android/repository/android-ndk-r26c-linux.zip" -o ndk.zip
+          unzip ndk.zip -d /home/runner/
+          rm ndk.zip
+
       - name: Create cargo config
+        if: steps.agent_cache.outputs.cache-hit != 'true'
         run: |
           echo '[target.aarch64-linux-android]
           ar = "${{ env.AR_aarch64-linux-android }}"
           linker = "${{ env.CC_aarch64-linux-android }}"' > /home/runner/.cargo/config.toml
+
       - name: Output cargo config
+        if: steps.agent_cache.outputs.cache-hit != 'true'
         run: cat /home/runner/.cargo/config.toml
+
       - name: Run agent build script
+        if: steps.agent_cache.outputs.cache-hit != 'true'
         run: ./build_agent.ps1 -Release
         shell: pwsh
+
+      - name: Site Hash
+        id: site_hash
+        run: |
+          echo "hash=$(find mbf-site -type f -exec md5sum {} \; | md5sum - | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Site Cache
+        id: site_cache
+        uses: actions/cache@v4
+        with:
+          key: mbf-site-${{ steps.site_hash.outputs.hash }}
+          path: |
+            mbf-site/dist
+
+      - uses: actions/setup-node@v3
+        if: steps.site_cache.outputs.cache-hit != 'true'
+        with:
+          node-version: 20.x
+
+      - name: Modules Cache
+        if: steps.site_cache.outputs.cache-hit != 'true'
+        id: modules_cache
+        uses: actions/cache@v4
+        with:
+          key: site-modules-${{ hashFiles('mbf-site/yarn.lock')}}
+          path: |
+            mbf-site/node_modules
+
       - name: yarn install
+        if: steps.modules_cache.outputs.cache-hit != 'true' && steps.site_cache.outputs.cache-hit != 'true'
         run: yarn --cwd ./mbf-site install
+
       - name: yarn build
-        run: yarn --cwd ./mbf-site build
+        if: steps.site_cache.outputs.cache-hit != 'true'
+        run: |
+          find mbf-site -type f
+          yarn --cwd ./mbf-site build
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: './mbf-site/dist'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: "Compile and deploy"
 on:
+  workflow_dispatch:
   push:
     branches: ['deploy']
 permissions:

--- a/mbf-site/vite.config.ts
+++ b/mbf-site/vite.config.ts
@@ -4,9 +4,9 @@ import viteTsconfigPaths from 'vite-tsconfig-paths'
 import mkcert from 'vite-plugin-mkcert'
 
 export default defineConfig({
-    base: process.env.BASE_URL ?? '/',
+    base: process.env.BASE_URL ?? './',
     plugins: [react(), viteTsconfigPaths(), mkcert()],
-    server: {    
+    server: {
         open: true,
         port: 3000,
         https: true


### PR DESCRIPTION
Enhance the build workflow by updating the NDK version to r27c, adjusting the base path, and implementing caching strategies to optimize build times.

If the source code hasn't changed, it won't build those portions in favor of utilizing the cached data.  If the agent has changed though, that requires a rebuild of the site.