### PR TITLE
Add safe, optional package-visibility requirements for QMODs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ MBF has some query parameters which can be passed with the URL. These are useful
 - `?dev=true`: This will override the normal version check, and always prompt the user to patch the currently installed Beat Saber game. NOTE: If you are not a mod developer, this **will not help you.** All it does is allows the modloader to be installed, it does not magically make the new version support mods and using this will only prevent you from downgrading Beat Saber. This is not "get mods only".
 - `?setcores=prompt`: This will prompt the user to enter an alternative core mods URL to use to test that the core mod JSON is ready for release. This URL will then be stored in the query parameter for future page refreshes.
 
+## QMOD Manifest Requirements
+
+QMOD schema 1.3.0 can declare narrowly typed Android package-visibility requirements. See the
+[format, compatibility, and security documentation](docs/qmod-manifest-requirements.md).
+
 ## Project Structure
 
 - `./mbf-agent` contains the agent, which is an executable written in Rust that is executed by the frontend via ADB. This agent does pretty much all the work, including installing mods and patching the game.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ MBF has some query parameters which can be passed with the URL. These are useful
 
 ## QMOD Manifest Requirements
 
-QMOD schema 1.3.0 can declare narrowly typed Android package-visibility requirements. See the
+This branch proposes a QMOD 1.3.0 extension for narrowly typed Android package-visibility
+requirements. See the
 [format, compatibility, and security documentation](docs/qmod-manifest-requirements.md).
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ MBF has some query parameters which can be passed with the URL. These are useful
 
 ## QMOD Manifest Requirements
 
-This branch proposes a QMOD 1.3.0 extension for narrowly typed Android package-visibility
-requirements. See the
+This branch proposes an optional, MBF-specific QMOD extension for narrowly typed Android
+package-visibility requirements without changing the QMOD format version. See the
 [format, compatibility, and security documentation](docs/qmod-manifest-requirements.md).
 
 ## Project Structure

--- a/docs/qmod-manifest-requirements.md
+++ b/docs/qmod-manifest-requirements.md
@@ -80,8 +80,7 @@ Schema validation.
 When a user-installed mod is enabled, the agent reads the installed binary Android manifest and verifies every
 request. If declarations are missing, it returns the requesting mod IDs and exact packages without
 copying those mods' files. The frontend automatically performs a manifest-only repatch and retries
-the original enable operation. There is no additional confirmation dialog, so the existing one-click
-patch/install flow is preserved. The agent verifies the installed manifest again on the retry.
+the original enable operation. The agent verifies the installed manifest again on the retry.
 Required dependencies use the same checks, including dependencies downloaded during the operation.
 
 Manifest-only repatches use Android's replace-existing install path and check the package manager's

--- a/docs/qmod-manifest-requirements.md
+++ b/docs/qmod-manifest-requirements.md
@@ -79,8 +79,8 @@ Schema validation.
 
 When a user-installed mod is enabled, the agent reads the installed binary Android manifest and verifies every
 request. If declarations are missing, it returns the requesting mod IDs and exact packages without
-copying those mods' files. The frontend automatically performs a manifest-only repatch and retries
-the original enable operation. The agent verifies the installed manifest again on the retry.
+copying those mods' files. The frontend automatically applies the manifest-only update and then
+continues enabling the mod. The agent verifies the installed manifest before enabling it.
 Required dependencies use the same checks, including dependencies downloaded during the operation.
 
 Manifest-only repatches use Android's replace-existing install path and check the package manager's

--- a/docs/qmod-manifest-requirements.md
+++ b/docs/qmod-manifest-requirements.md
@@ -1,0 +1,82 @@
+# QMOD Android manifest requirements
+
+MBF supports a deliberately limited manifest-requirements extension for QMOD schema version
+1.3.0. It lets a mod declare specific Android packages that must be visible through
+`PackageManager` on Android 11 and newer.
+
+```json
+{
+  "_QPVersion": "1.3.0",
+  "name": "Discord integration example",
+  "id": "discord-integration-example",
+  "author": "Example",
+  "version": "1.0.0",
+  "modFiles": ["libdiscord-integration-example.so"],
+  "manifestRequirements": {
+    "queryPackages": ["com.discord"]
+  }
+}
+```
+
+This produces the following declaration if it is not already present:
+
+```xml
+<queries>
+    <package android:name="com.discord" />
+</queries>
+```
+
+Android documents this declaration as making the named app visible to matching
+`PackageManager` queries. It does not grant an Android permission. See Android's
+[package visibility documentation](https://developer.android.com/training/package-visibility/declaring)
+and [`<queries>` reference](https://developer.android.com/guide/topics/manifest/queries-element).
+
+## Validation and approval
+
+`manifestRequirements` is optional. Existing QMODs through schema version 1.2.0 remain valid and
+behave exactly as before. A QMOD that uses `manifestRequirements` must specify `_QPVersion` 1.3.0,
+so older installers fail clearly instead of silently ignoring a requirement and enabling a broken
+mod.
+
+MBF accepts at most 32 unique package IDs per QMOD. Each ID is at most 255 ASCII characters, has at
+least two dot-separated components, starts every component with a letter, and otherwise contains
+only letters, digits, or underscores. The Rust agent repeats these checks after JSON Schema
+validation.
+
+When a mod is enabled, the agent reads the installed binary Android manifest and verifies every
+request. If declarations are missing, it returns the requesting mod IDs and exact packages without
+copying those mods' files. The frontend shows that list and asks the user before repatching. The
+agent then verifies the installed manifest again on the retry. Required dependencies use the same
+checks, including dependencies downloaded during the operation.
+
+Manifest-only repatches use Android's replace-existing install path and check the package manager's
+result. A rejected generated APK therefore leaves the existing app installed.
+
+## Security boundary and non-goals
+
+QMODs cannot provide raw XML or choose an insertion point. The schema rejects unknown members
+inside `manifestRequirements`, including permission lists. This version intentionally does not
+support:
+
+- `uses-permission`, including `QUERY_ALL_PACKAGES`, runtime/dangerous permissions, or special
+  permissions;
+- components such as activities, services, receivers, or providers;
+- intent/provider forms of package visibility;
+- features, native libraries, metadata, attributes, or arbitrary XML.
+
+These are separate security and compatibility decisions. Android notes that dangerous permissions
+provide access to restricted data or actions, so accepting them would require a permission-specific
+allowlist, prominent consent, and substantially more policy than package visibility. See Android's
+[permissions overview](https://developer.android.com/guide/topics/permissions/overview).
+
+This first version is additive. Disabling or removing a mod does not remove package visibility that
+MBF previously added. Retaining a narrow package declaration is safer than deleting a declaration
+that may have existed in the original game manifest or may still be shared by another mod. A future
+removal feature would need persistent provenance and reference counting.
+
+## Compatibility note
+
+Version 1.3.0 is a proposed QMOD schema addition. Before mods publish QMODs that depend on it, the
+canonical QMOD model/schema and other active installers should adopt the same typed field. Keeping
+the version gate is important: merely adding an optional property to version 1.2.0 would let older
+installers accept the archive, ignore the requirement, and report a misleading successful install.

--- a/docs/qmod-manifest-requirements.md
+++ b/docs/qmod-manifest-requirements.md
@@ -31,7 +31,7 @@ Android documents this declaration as making the named app visible to matching
 [package visibility documentation](https://developer.android.com/training/package-visibility/declaring)
 and [`<queries>` reference](https://developer.android.com/guide/topics/manifest/queries-element).
 
-## Validation and approval
+## Validation and automatic application
 
 `manifestRequirements` is optional. Existing QMODs through schema version 1.2.0 remain valid and
 behave exactly as before. A QMOD that uses `manifestRequirements` must specify `_QPVersion` 1.3.0,
@@ -45,9 +45,10 @@ validation.
 
 When a mod is enabled, the agent reads the installed binary Android manifest and verifies every
 request. If declarations are missing, it returns the requesting mod IDs and exact packages without
-copying those mods' files. The frontend shows that list and asks the user before repatching. The
-agent then verifies the installed manifest again on the retry. Required dependencies use the same
-checks, including dependencies downloaded during the operation.
+copying those mods' files. The frontend automatically performs a manifest-only repatch and retries
+the original enable operation. This preserves MBF's one-click install flow while keeping enforcement
+in the typed schema and Rust agent. The agent verifies the installed manifest again on the retry.
+Required dependencies use the same checks, including dependencies downloaded during the operation.
 
 Manifest-only repatches use Android's replace-existing install path and check the package manager's
 result. A rejected generated APK therefore leaves the existing app installed.

--- a/docs/qmod-manifest-requirements.md
+++ b/docs/qmod-manifest-requirements.md
@@ -1,7 +1,7 @@
 # QMOD Android manifest requirements
 
-MBF supports a deliberately limited manifest-requirements extension for QMOD schema version
-1.3.0. It lets a mod declare specific Android packages that must be visible through
+This branch proposes a deliberately limited manifest-requirements extension for QMOD schema
+version 1.3.0. It lets a mod declare specific Android packages that must be visible through
 `PackageManager` on Android 11 and newer.
 
 ```json
@@ -38,10 +38,10 @@ behave exactly as before. A QMOD that uses `manifestRequirements` must specify `
 so older installers fail clearly instead of silently ignoring a requirement and enabling a broken
 mod.
 
-MBF accepts at most 32 unique package IDs per QMOD. Each ID is at most 255 ASCII characters, has at
-least two dot-separated components, starts every component with a letter, and otherwise contains
-only letters, digits, or underscores. The Rust agent repeats these checks after JSON Schema
-validation.
+MBF accepts between 1 and 32 unique package IDs per QMOD. Each ID is at most 255 ASCII characters,
+has at least two dot-separated components, starts every component with a letter, and otherwise
+contains only letters, digits, or underscores. The Rust agent repeats these checks after JSON
+Schema validation.
 
 When a mod is enabled, the agent reads the installed binary Android manifest and verifies every
 request. If declarations are missing, it returns the requesting mod IDs and exact packages without
@@ -78,6 +78,19 @@ removal feature would need persistent provenance and reference counting.
 ## Compatibility note
 
 Version 1.3.0 is a proposed QMOD schema addition. Before mods publish QMODs that depend on it, the
-canonical QMOD model/schema and other active installers should adopt the same typed field. Keeping
-the version gate is important: merely adding an optional property to version 1.2.0 would let older
-installers accept the archive, ignore the requirement, and report a misleading successful install.
+[canonical QuestPatcher.QMod model and schema](https://github.com/Lauriethefish/QuestPatcher.QMod)
+and other active installers should adopt the same typed field. QPM's current typed QMOD model also
+needs to preserve and generate the field; otherwise rebuilding a `mod.template.json` can omit it.
+Keeping the version gate is important: merely adding an optional property to version 1.2.0 would
+let older installers accept the archive, ignore the requirement, and report a misleading
+successful install.
+
+The recommended merge order is therefore:
+
+1. agree on the field and version in the canonical QuestPatcher.QMod repository;
+2. add the field to the canonical schema/library and QPM's typed model;
+3. merge installer support such as this MBF implementation; and
+4. only then publish mods that depend on the new version.
+
+Until the canonical proposal is accepted, this MBF branch is an implementation reference and
+should not be treated as a final QMOD 1.3.0 definition.

--- a/docs/qmod-manifest-requirements.md
+++ b/docs/qmod-manifest-requirements.md
@@ -1,24 +1,24 @@
-# QMOD Android manifest requirements
+# MBF QMOD Android manifest requirements
 
-This branch proposes a deliberately limited manifest-requirements extension for QMOD schema
-version 1.3.0. It lets a mod declare specific Android packages that must be visible through
-`PackageManager` on Android 11 and newer.
+MBF supports a deliberately limited, optional QMOD extension that lets a mod declare Android
+packages that must be visible through `PackageManager` on Android 11 and newer. It is namespaced
+to MBF and does not claim a new version of the shared QMOD format.
 
 ```json
 {
-  "_QPVersion": "1.3.0",
+  "_QPVersion": "0.1.2",
   "name": "Discord integration example",
   "id": "discord-integration-example",
   "author": "Example",
   "version": "1.0.0",
   "modFiles": ["libdiscord-integration-example.so"],
-  "manifestRequirements": {
+  "mbfManifestRequirements": {
     "queryPackages": ["com.discord"]
   }
 }
 ```
 
-This produces the following declaration if it is not already present:
+If it is not already present, MBF adds:
 
 ```xml
 <queries>
@@ -31,32 +31,70 @@ Android documents this declaration as making the named app visible to matching
 [package visibility documentation](https://developer.android.com/training/package-visibility/declaring)
 and [`<queries>` reference](https://developer.android.com/guide/topics/manifest/queries-element).
 
-## Validation and automatic application
+## Compatibility and packaging
 
-`manifestRequirements` is optional. Existing QMODs through schema version 1.2.0 remain valid and
-behave exactly as before. A QMOD that uses `manifestRequirements` must specify `_QPVersion` 1.3.0,
-so older installers fail clearly instead of silently ignoring a requirement and enabling a broken
-mod.
+`mbfManifestRequirements` is optional. QMODs that omit it behave exactly as before, and the
+extension works with every QMOD schema version MBF already supports. The shared `_QPVersion`
+therefore remains unchanged.
+
+The standard QMOD schema permits additional root properties, so compatible installers that do not
+implement this MBF extension can ignore it. A mod that relies on the declaration should still
+detect an unavailable target package or service at runtime and give the user an actionable message;
+that covers installation through an older MBF release or a different installer.
+
+QPM.CLI currently regenerates `mod.json` from its typed model and does not preserve unknown fields
+from `mod.template.json`. A producing repository must therefore add this extension after
+`qpm qmod zip`, then verify that the final archive contains the exact declaration and that every
+non-manifest payload is byte-for-byte unchanged.
+
+This avoids requiring coordinated changes to the QMOD specification and packaging libraries for a
+feature needed by one mod. It also makes ownership explicit: this field is an MBF contract, not a
+portable guarantee provided by every QMOD installer.
+
+### Future native QPM producer support
+
+The post-build step is a workaround for the current QPM producer toolchain, not a permanent format
+requirement. QPM.CLI reads `mod.template.json` and writes the generated `mod.json` through the
+`ModJson` model supplied by the separate QPM.qmod library. That model currently does not retain this
+MBF-specific root property, including when QPM.CLI packages an imported manifest.
+
+First-class producer support therefore requires both tooling layers to change:
+
+1. QPM.qmod must preserve namespaced root extensions such as `mbfManifestRequirements`, either as
+   an explicit optional field or through a generic flattened extension map.
+2. QPM.CLI must update its QPM.qmod dependency and lockfile, then add round-trip coverage for
+   `qmod manifest`, `qmod zip`, and `qmod zip --import`.
+3. A QPM.CLI release containing that support must be available before producer repositories remove
+   their verified post-build step.
+
+This is a mod-author packaging limitation. It does not affect users installing a completed QMOD,
+does not block MBF support, and does not require a new shared `_QPVersion`.
+
+## Validation and automatic application
 
 MBF accepts between 1 and 32 unique package IDs per QMOD. Each ID is at most 255 ASCII characters,
 has at least two dot-separated components, starts every component with a letter, and otherwise
 contains only letters, digits, or underscores. The Rust agent repeats these checks after JSON
 Schema validation.
 
-When a mod is enabled, the agent reads the installed binary Android manifest and verifies every
+When a user-installed mod is enabled, the agent reads the installed binary Android manifest and verifies every
 request. If declarations are missing, it returns the requesting mod IDs and exact packages without
 copying those mods' files. The frontend automatically performs a manifest-only repatch and retries
-the original enable operation. This preserves MBF's one-click install flow while keeping enforcement
-in the typed schema and Rust agent. The agent verifies the installed manifest again on the retry.
+the original enable operation. There is no additional confirmation dialog, so the existing one-click
+patch/install flow is preserved. The agent verifies the installed manifest again on the retry.
 Required dependencies use the same checks, including dependencies downloaded during the operation.
 
 Manifest-only repatches use Android's replace-existing install path and check the package manager's
 result. A rejected generated APK therefore leaves the existing app installed.
 
+Core mods from the resource index are outside this initial extension because their index metadata
+does not carry QMOD manifest requirements before the initial patch. Supporting that separately
+would require an explicit resource-index contract.
+
 ## Security boundary and non-goals
 
 QMODs cannot provide raw XML or choose an insertion point. The schema rejects unknown members
-inside `manifestRequirements`, including permission lists. This version intentionally does not
+inside `mbfManifestRequirements`, including permission lists. This extension intentionally does not
 support:
 
 - `uses-permission`, including `QUERY_ALL_PACKAGES`, runtime/dangerous permissions, or special
@@ -74,23 +112,3 @@ This first version is additive. Disabling or removing a mod does not remove pack
 MBF previously added. Retaining a narrow package declaration is safer than deleting a declaration
 that may have existed in the original game manifest or may still be shared by another mod. A future
 removal feature would need persistent provenance and reference counting.
-
-## Compatibility note
-
-Version 1.3.0 is a proposed QMOD schema addition. Before mods publish QMODs that depend on it, the
-[canonical QuestPatcher.QMod model and schema](https://github.com/Lauriethefish/QuestPatcher.QMod)
-and other active installers should adopt the same typed field. QPM's current typed QMOD model also
-needs to preserve and generate the field; otherwise rebuilding a `mod.template.json` can omit it.
-Keeping the version gate is important: merely adding an optional property to version 1.2.0 would
-let older installers accept the archive, ignore the requirement, and report a misleading
-successful install.
-
-The recommended merge order is therefore:
-
-1. agree on the field and version in the canonical QuestPatcher.QMod repository;
-2. add the field to the canonical schema/library and QPM's typed model;
-3. merge installer support such as this MBF implementation; and
-4. only then publish mods that depend on the new version.
-
-Until the canonical proposal is accepted, this MBF branch is an implementation reference and
-should not be treated as a final QMOD 1.3.0 definition.

--- a/mbf-agent/src/handlers/mod.rs
+++ b/mbf-agent/src/handlers/mod.rs
@@ -151,7 +151,7 @@ fn install_core_mods(
         .load_mods()
         .context("Loading core mods - is one invalid? If so, this is a BIG problem")?;
     for core_mod in &core_mods.mods {
-        mod_manager.install_mod(&core_mod.id)?;
+        mod_manager.install_mod_with_manifest(&core_mod.id, &app_info.query_packages)?;
     }
     mod_status::mark_all_core_mods(&mod_manager, &core_mods.mods);
 

--- a/mbf-agent/src/handlers/mod_management.rs
+++ b/mbf-agent/src/handlers/mod_management.rs
@@ -4,10 +4,10 @@
 use std::collections::HashMap;
 
 use crate::{
-    mod_man::ModManager,
-    models::response::{ModModel, Response},
+    mod_man::{MissingManifestRequirements, ModManager},
+    models::response::{MissingManifestRequirementModel, ModModel, Response},
 };
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use log::info;
 
 /// Handles `SetModsEnabled` [Requests](crate::requests::Request).
@@ -15,12 +15,41 @@ use log::info;
 /// # Returns
 /// The [Response] to the request (variant `ModSyncResult`)
 pub(super) fn handle_set_mods_enabled(statuses: HashMap<String, bool>) -> Result<Response> {
+    let app_info = super::mod_status::get_app_info()?
+        .ok_or_else(|| anyhow!("Cannot enable mods when Beat Saber is not installed"))?;
     let res_cache = crate::load_res_cache()?;
 
-    let mut mod_manager = ModManager::new(super::get_app_version_only()?, &res_cache);
+    let mut mod_manager = ModManager::new(app_info.version, &res_cache);
     mod_manager.load_mods().context("Loading installed mods")?;
 
     let mut error = String::new();
+    let mut missing_requirements = Vec::new();
+
+    // This preflight is deliberately performed before any requested status is changed. It covers
+    // every dependency that is already downloaded, allowing the UI to ask for one approval and
+    // repatch before mod files are copied.
+    for (id, new_status) in &statuses {
+        if !new_status {
+            continue;
+        }
+
+        let mod_rc = match mod_manager.get_mod(id) {
+            Some(mod_rc) => mod_rc,
+            None => continue,
+        };
+        if !mod_rc.borrow().installed() {
+            missing_requirements
+                .extend(mod_manager.missing_manifest_requirements(id, &app_info.query_packages)?);
+        }
+    }
+
+    if !missing_requirements.is_empty() {
+        return Ok(Response::ModSyncResult {
+            installed_mods: get_mod_models(mod_manager)?,
+            failures: None,
+            manifest_changes_required: requirement_models(missing_requirements),
+        });
+    }
 
     for (id, new_status) in statuses {
         let mod_rc = match mod_manager.get_mod(&id) {
@@ -33,9 +62,15 @@ pub(super) fn handle_set_mods_enabled(statuses: HashMap<String, bool>) -> Result
 
         let already_installed = mod_rc.borrow().installed();
         if new_status && !already_installed {
-            match mod_manager.install_mod(&id) {
+            match mod_manager.install_mod_with_manifest(&id, &app_info.query_packages) {
                 Ok(_) => info!("Installed {id}"),
-                Err(err) => error.push_str(&format!("Failed to install {id}: {err}\n")),
+                Err(err) => {
+                    if let Some(requirements) = err.downcast_ref::<MissingManifestRequirements>() {
+                        missing_requirements.push(requirements.clone());
+                    } else {
+                        error.push_str(&format!("Failed to install {id}: {err}\n"));
+                    }
+                }
             }
         } else if !new_status && already_installed {
             match mod_manager.uninstall_mod(&id) {
@@ -47,7 +82,7 @@ pub(super) fn handle_set_mods_enabled(statuses: HashMap<String, bool>) -> Result
 
     Ok(Response::ModSyncResult {
         installed_mods: get_mod_models(mod_manager)?,
-        failures: if error.len() > 0 {
+        failures: if !error.is_empty() {
             if error.ends_with('\n') {
                 error.pop();
             }
@@ -56,7 +91,33 @@ pub(super) fn handle_set_mods_enabled(statuses: HashMap<String, bool>) -> Result
         } else {
             None
         },
+        manifest_changes_required: requirement_models(missing_requirements),
     })
+}
+
+fn requirement_models(
+    missing_requirements: Vec<MissingManifestRequirements>,
+) -> Vec<MissingManifestRequirementModel> {
+    let mut models = Vec::<MissingManifestRequirementModel>::new();
+    for requirement in missing_requirements {
+        if let Some(existing) = models
+            .iter_mut()
+            .find(|existing| existing.mod_id == requirement.mod_id)
+        {
+            for package in requirement.query_packages {
+                if !existing.query_packages.contains(&package) {
+                    existing.query_packages.push(package);
+                }
+            }
+        } else {
+            models.push(MissingManifestRequirementModel {
+                mod_id: requirement.mod_id,
+                query_packages: requirement.query_packages,
+            });
+        }
+    }
+
+    models
 }
 
 /// Handles `RemoveMod` [Requests](crate::requests::Request).

--- a/mbf-agent/src/handlers/mod_management.rs
+++ b/mbf-agent/src/handlers/mod_management.rs
@@ -120,6 +120,50 @@ fn requirement_models(
     models
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requirement_models_merge_duplicate_reports_for_one_mod() {
+        let models = requirement_models(vec![
+            MissingManifestRequirements {
+                mod_id: "example-mod".to_string(),
+                query_packages: vec!["com.discord".to_string()],
+            },
+            MissingManifestRequirements {
+                mod_id: "example-mod".to_string(),
+                query_packages: vec!["com.discord".to_string(), "com.spotify.music".to_string()],
+            },
+        ]);
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].mod_id, "example-mod");
+        assert_eq!(
+            models[0].query_packages,
+            vec!["com.discord", "com.spotify.music"]
+        );
+    }
+
+    #[test]
+    fn requirement_models_keep_requesting_mods_separate() {
+        let models = requirement_models(vec![
+            MissingManifestRequirements {
+                mod_id: "first-mod".to_string(),
+                query_packages: vec!["com.discord".to_string()],
+            },
+            MissingManifestRequirements {
+                mod_id: "second-mod".to_string(),
+                query_packages: vec!["com.discord".to_string()],
+            },
+        ]);
+
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].mod_id, "first-mod");
+        assert_eq!(models[1].mod_id, "second-mod");
+    }
+}
+
 /// Handles `RemoveMod` [Requests](crate::requests::Request).
 ///
 /// # Returns

--- a/mbf-agent/src/handlers/mod_management.rs
+++ b/mbf-agent/src/handlers/mod_management.rs
@@ -26,7 +26,7 @@ pub(super) fn handle_set_mods_enabled(statuses: HashMap<String, bool>) -> Result
     let mut missing_requirements = Vec::new();
 
     // This preflight is deliberately performed before any requested status is changed. It covers
-    // every dependency that is already downloaded, allowing the UI to ask for one approval and
+    // every dependency that is already downloaded, allowing the UI to complete one automatic
     // repatch before mod files are copied.
     for (id, new_status) in &statuses {
         if !new_status {

--- a/mbf-agent/src/handlers/mod_status.rs
+++ b/mbf-agent/src/handlers/mod_status.rs
@@ -75,6 +75,7 @@ pub(super) fn get_app_info() -> Result<Option<response::AppInfo>> {
         obb_present,
         path: apk_path,
         manifest_xml,
+        query_packages: manifest_info.query_packages,
     }))
 }
 

--- a/mbf-agent/src/manifest.rs
+++ b/mbf-agent/src/manifest.rs
@@ -127,4 +127,27 @@ mod tests {
 
         assert!(info.query_packages.is_empty());
     }
+
+    #[test]
+    fn reads_all_direct_queries_and_requires_the_android_name_namespace() {
+        let info = read_manifest(
+            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                          xmlns:other="https://example.com/not-android"
+                          android:versionName="1.40.8">
+                <queries>
+                    <package other:name="com.ignored.wrongnamespace" />
+                    <package android:name="com.discord" />
+                </queries>
+                <queries>
+                    <package android:name="com.spotify.music" />
+                    <package android:name="com.discord" />
+                </queries>
+            </manifest>"#,
+        );
+
+        assert_eq!(
+            info.query_packages,
+            HashSet::from(["com.discord".to_string(), "com.spotify.music".to_string()])
+        );
+    }
 }

--- a/mbf-agent/src/manifest.rs
+++ b/mbf-agent/src/manifest.rs
@@ -1,48 +1,130 @@
 //! Module containing convenience functions for modifying AndroidManifest.xml
 
-use std::io::{Read, Seek};
+use std::{
+    collections::HashSet,
+    io::{Read, Seek},
+};
 
 use anyhow::{anyhow, Result};
 
-use mbf_axml::{AttributeValue, AxmlReader, Event};
+use mbf_axml::{AttributeValue, AxmlReader, Event, ANDROID_NS_URI};
 
 /// Useful struct to read key details from the APK manifest.
 pub struct ManifestInfo {
     pub package_version: String,
+    pub query_packages: HashSet<String>,
 }
 
 impl ManifestInfo {
     pub fn read<T: Read + Seek>(reader: &mut AxmlReader<T>) -> Result<Self> {
         let mut version: Option<String> = None;
+        let mut query_packages = HashSet::new();
+        let mut element_depth = 0usize;
+        let mut queries_depth = None;
         while let Some(event) = reader.read_next_event()? {
             match event {
                 Event::StartElement {
                     attributes, name, ..
                 } => {
-                    if &*name != "manifest" {
-                        continue;
+                    element_depth += 1;
+                    if name == "queries" && element_depth == 2 {
+                        queries_depth = Some(element_depth);
                     }
 
-                    let version_attr = attributes
-                        .iter()
-                        .filter(|attr| &*attr.name == "versionName")
-                        .next();
+                    if name == "manifest" {
+                        let version_attr =
+                            attributes.iter().find(|attr| attr.name == "versionName");
 
-                    match version_attr {
-                        Some(attr) => match &attr.value {
-                            AttributeValue::String(s) => version = Some(s.to_string()),
-                            _ => return Err(anyhow!("Package version must be a string")),
-                        },
-                        None => return Err(anyhow!("No package version attribute")),
+                        match version_attr {
+                            Some(attr) => match &attr.value {
+                                AttributeValue::String(s) => version = Some(s.to_string()),
+                                _ => return Err(anyhow!("Package version must be a string")),
+                            },
+                            None => return Err(anyhow!("No package version attribute")),
+                        }
+                    } else if name == "package"
+                        && queries_depth.is_some_and(|depth| element_depth == depth + 1)
+                    {
+                        if let Some(AttributeValue::String(package_name)) = attributes
+                            .iter()
+                            .find(|attribute| {
+                                attribute.name == "name"
+                                    && attribute.namespace.as_deref() == Some(ANDROID_NS_URI)
+                            })
+                            .map(|attribute| &attribute.value)
+                        {
+                            query_packages.insert(package_name.clone());
+                        }
                     }
+                }
+                Event::EndElement { name, .. } => {
+                    if name == "queries" && queries_depth == Some(element_depth) {
+                        queries_depth = None;
+                    }
+                    element_depth = element_depth.saturating_sub(1);
                 }
                 _ => {}
             }
         }
 
         match version {
-            Some(package_version) => Ok(Self { package_version }),
+            Some(package_version) => Ok(Self {
+                package_version,
+                query_packages,
+            }),
             None => Err(anyhow!("No useful information found in the manifest")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use mbf_axml::AxmlWriter;
+
+    use super::*;
+
+    fn read_manifest(xml: &str) -> ManifestInfo {
+        let mut binary_manifest = Cursor::new(Vec::new());
+        let mut axml_writer = AxmlWriter::new(&mut binary_manifest);
+        let mut xml_reader = xml::EventReader::new(Cursor::new(xml.as_bytes()));
+        mbf_axml::xml_to_axml(&mut axml_writer, &mut xml_reader).unwrap();
+        axml_writer.finish().unwrap();
+
+        binary_manifest.set_position(0);
+        let mut axml_reader = AxmlReader::new(&mut binary_manifest).unwrap();
+        ManifestInfo::read(&mut axml_reader).unwrap()
+    }
+
+    #[test]
+    fn reads_query_packages_from_the_manifest() {
+        let info = read_manifest(
+            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.40.8">
+                <queries>
+                    <package android:name="com.discord" />
+                    <package android:name="com.spotify.music" />
+                </queries>
+                <application />
+            </manifest>"#,
+        );
+
+        assert_eq!(info.package_version, "1.40.8");
+        assert_eq!(
+            info.query_packages,
+            HashSet::from(["com.discord".to_string(), "com.spotify.music".to_string()])
+        );
+    }
+
+    #[test]
+    fn ignores_package_elements_outside_direct_queries_children() {
+        let info = read_manifest(
+            r#"<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.40.8">
+                <queries><intent><package android:name="com.not-a-query-package" /></intent></queries>
+                <application><package android:name="com.also-ignored" /></application>
+            </manifest>"#,
+        );
+
+        assert!(info.query_packages.is_empty());
     }
 }

--- a/mbf-agent/src/mod_man/manifest.rs
+++ b/mbf-agent/src/mod_man/manifest.rs
@@ -50,6 +50,12 @@ pub struct ManifestRequirements {
 impl ManifestRequirements {
     /// Validates limits that must remain enforced even if schema validation is bypassed or changed.
     pub fn validate(&self) -> Result<()> {
+        if self.query_packages.is_empty() {
+            return Err(anyhow!(
+                "A manifestRequirements object must request at least one query package"
+            ));
+        }
+
         if self.query_packages.len() > MAX_QUERY_PACKAGES {
             return Err(anyhow!(
                 "A QMOD may request at most {MAX_QUERY_PACKAGES} query packages"
@@ -286,6 +292,11 @@ mod tests {
 
     #[test]
     fn rejects_duplicate_or_excessive_query_packages() {
+        let empty = ManifestRequirements {
+            query_packages: Vec::new(),
+        };
+        assert!(empty.validate().is_err());
+
         let duplicate = ManifestRequirements {
             query_packages: vec!["com.discord".to_string(), "com.discord".to_string()],
         };
@@ -297,6 +308,17 @@ mod tests {
                 .collect(),
         };
         assert!(excessive.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_the_maximum_number_of_query_packages() {
+        let requirements = ManifestRequirements {
+            query_packages: (0..MAX_QUERY_PACKAGES)
+                .map(|index| format!("com.example.package{index}"))
+                .collect(),
+        };
+
+        requirements.validate().unwrap();
     }
 
     #[test]

--- a/mbf-agent/src/mod_man/manifest.rs
+++ b/mbf-agent/src/mod_man/manifest.rs
@@ -35,7 +35,7 @@ impl Display for MissingManifestRequirements {
 
 impl std::error::Error for MissingManifestRequirements {}
 
-/// Declarative Android manifest requirements for a QMOD.
+/// Declarative Android manifest requirements for MBF's optional QMOD extension.
 ///
 /// This intentionally exposes a small, typed surface rather than accepting raw XML. New
 /// requirement types should be added individually after defining their validation, compatibility,
@@ -52,7 +52,7 @@ impl ManifestRequirements {
     pub fn validate(&self) -> Result<()> {
         if self.query_packages.is_empty() {
             return Err(anyhow!(
-                "A manifestRequirements object must request at least one query package"
+                "An mbfManifestRequirements object must request at least one query package"
             ));
         }
 
@@ -164,10 +164,10 @@ pub struct ModInfo {
     pub file_copies: Vec<FileCopy>,
     /// list of copy extensions registered for this specific mod
     pub copy_extensions: Vec<CopyExtension>,
-    /// Optional, typed requirements that must exist in the patched Android manifest before this
-    /// mod is enabled.
+    /// Optional MBF-specific requirements that must exist in the patched Android manifest before
+    /// this mod is enabled. Other QMOD installers may safely ignore this root extension.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub manifest_requirements: Option<ManifestRequirements>,
+    pub mbf_manifest_requirements: Option<ManifestRequirements>,
 }
 
 impl Default for ModInfo {
@@ -189,7 +189,7 @@ impl Default for ModInfo {
             library_files: Default::default(),
             file_copies: Default::default(),
             copy_extensions: Default::default(),
-            manifest_requirements: Default::default(),
+            mbf_manifest_requirements: Default::default(),
             modloader: Some("Scotland2".into()),
             late_mod_files: Default::default(),
         }
@@ -245,7 +245,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn manifest_requirements_are_optional_for_existing_qmods() {
+    fn mbf_manifest_requirements_are_optional_for_existing_qmods() {
         let manifest: ModInfo = serde_json::from_value(serde_json::json!({
             "_QPVersion": "1.2.0",
             "name": "Legacy mod",
@@ -255,7 +255,30 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(manifest.manifest_requirements, None);
+        assert_eq!(manifest.mbf_manifest_requirements, None);
+    }
+
+    #[test]
+    fn deserializes_mbf_manifest_requirements_without_changing_qmod_version() {
+        let manifest: ModInfo = serde_json::from_value(serde_json::json!({
+            "_QPVersion": "0.1.2",
+            "name": "Discord integration",
+            "id": "discord-integration",
+            "author": "Example",
+            "version": "1.0.0",
+            "mbfManifestRequirements": {
+                "queryPackages": ["com.discord"]
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(manifest.schema_version, Version::new(0, 1, 2));
+        assert_eq!(
+            manifest.mbf_manifest_requirements,
+            Some(ManifestRequirements {
+                query_packages: vec!["com.discord".to_string()]
+            })
+        );
     }
 
     #[test]

--- a/mbf-agent/src/mod_man/manifest.rs
+++ b/mbf-agent/src/mod_man/manifest.rs
@@ -5,8 +5,110 @@
 //! This code is under the GNU General Public License version 3, found here:
 //! https://github.com/QuestPackageManager/QPM.qmod/blob/main/LICENSE
 
+use std::collections::HashSet;
+use std::fmt::{Display, Formatter};
+
+use anyhow::{anyhow, Result};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
+
+/// The maximum number of package-visibility declarations one QMOD may request.
+pub const MAX_QUERY_PACKAGES: usize = 32;
+
+/// Returned when enabling a mod would leave one or more declared requirements unsatisfied.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MissingManifestRequirements {
+    pub mod_id: String,
+    pub query_packages: Vec<String>,
+}
+
+impl Display for MissingManifestRequirements {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Mod {} requires missing manifest query packages: {}",
+            self.mod_id,
+            self.query_packages.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for MissingManifestRequirements {}
+
+/// Declarative Android manifest requirements for a QMOD.
+///
+/// This intentionally exposes a small, typed surface rather than accepting raw XML. New
+/// requirement types should be added individually after defining their validation and approval
+/// policy.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ManifestRequirements {
+    /// Android package IDs that must be visible through PackageManager.
+    pub query_packages: Vec<String>,
+}
+
+impl ManifestRequirements {
+    /// Validates limits that must remain enforced even if schema validation is bypassed or changed.
+    pub fn validate(&self) -> Result<()> {
+        if self.query_packages.len() > MAX_QUERY_PACKAGES {
+            return Err(anyhow!(
+                "A QMOD may request at most {MAX_QUERY_PACKAGES} query packages"
+            ));
+        }
+
+        let mut unique_packages = HashSet::new();
+        for package in &self.query_packages {
+            if !is_valid_android_package_name(package) {
+                return Err(anyhow!(
+                    "Manifest query package `{package}` is not a valid Android package name"
+                ));
+            }
+            if !unique_packages.insert(package) {
+                return Err(anyhow!(
+                    "Manifest query package `{package}` was requested more than once"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns the requested packages that are not already declared by the app manifest.
+    pub fn missing_query_packages(&self, declared: &HashSet<String>) -> Vec<String> {
+        self.query_packages
+            .iter()
+            .filter(|package| !declared.contains(*package))
+            .cloned()
+            .collect()
+    }
+}
+
+/// A conservative package-name validator for values written to `android:name`.
+///
+/// Names are limited to ASCII, contain at least two dot-separated segments, and each segment
+/// starts with a letter. This covers conventional Android application IDs while excluding XML,
+/// whitespace and resource syntax.
+fn is_valid_android_package_name(package: &str) -> bool {
+    if package.len() > 255 {
+        return false;
+    }
+
+    let mut segments = package.split('.');
+    let mut segment_count = 0;
+    for segment in &mut segments {
+        segment_count += 1;
+        let mut chars = segment.chars();
+        if !chars
+            .next()
+            .is_some_and(|character| character.is_ascii_alphabetic())
+            || !chars.all(|character| character.is_ascii_alphanumeric() || character == '_')
+        {
+            return false;
+        }
+    }
+
+    segment_count >= 2
+}
 
 /// Model for the `mod.json` manifest within a QMOD.
 #[derive(Deserialize, Clone, Debug)]
@@ -56,6 +158,10 @@ pub struct ModInfo {
     pub file_copies: Vec<FileCopy>,
     /// list of copy extensions registered for this specific mod
     pub copy_extensions: Vec<CopyExtension>,
+    /// Optional, typed requirements that must exist in the patched Android manifest before this
+    /// mod is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_requirements: Option<ManifestRequirements>,
 }
 
 impl Default for ModInfo {
@@ -77,6 +183,7 @@ impl Default for ModInfo {
             library_files: Default::default(),
             file_copies: Default::default(),
             copy_extensions: Default::default(),
+            manifest_requirements: Default::default(),
             modloader: Some("Scotland2".into()),
             late_mod_files: Default::default(),
         }
@@ -125,4 +232,83 @@ pub struct CopyExtension {
 
 fn true_default() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_requirements_are_optional_for_existing_qmods() {
+        let manifest: ModInfo = serde_json::from_value(serde_json::json!({
+            "_QPVersion": "1.2.0",
+            "name": "Legacy mod",
+            "id": "legacy-mod",
+            "author": "Example",
+            "version": "1.0.0"
+        }))
+        .unwrap();
+
+        assert_eq!(manifest.manifest_requirements, None);
+    }
+
+    #[test]
+    fn accepts_conventional_android_package_names() {
+        let requirements = ManifestRequirements {
+            query_packages: vec![
+                "com.discord".to_string(),
+                "com.AnotherAxiom.GorillaTag".to_string(),
+                "io.example_app.client2".to_string(),
+            ],
+        };
+
+        requirements.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_unsafe_or_ambiguous_package_names() {
+        for invalid in [
+            "discord",
+            ".com.discord",
+            "com..discord",
+            "com.2discord",
+            "com.discord-beta",
+            "com.discord/other",
+            "com.discord\" />",
+            "com.discórd",
+        ] {
+            let requirements = ManifestRequirements {
+                query_packages: vec![invalid.to_string()],
+            };
+            assert!(requirements.validate().is_err(), "accepted `{invalid}`");
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_or_excessive_query_packages() {
+        let duplicate = ManifestRequirements {
+            query_packages: vec!["com.discord".to_string(), "com.discord".to_string()],
+        };
+        assert!(duplicate.validate().is_err());
+
+        let excessive = ManifestRequirements {
+            query_packages: (0..=MAX_QUERY_PACKAGES)
+                .map(|index| format!("com.example.package{index}"))
+                .collect(),
+        };
+        assert!(excessive.validate().is_err());
+    }
+
+    #[test]
+    fn reports_only_packages_missing_from_the_manifest() {
+        let requirements = ManifestRequirements {
+            query_packages: vec!["com.discord".to_string(), "com.spotify.music".to_string()],
+        };
+        let declared = HashSet::from(["com.discord".to_string()]);
+
+        assert_eq!(
+            requirements.missing_query_packages(&declared),
+            vec!["com.spotify.music"]
+        );
+    }
 }

--- a/mbf-agent/src/mod_man/manifest.rs
+++ b/mbf-agent/src/mod_man/manifest.rs
@@ -38,8 +38,8 @@ impl std::error::Error for MissingManifestRequirements {}
 /// Declarative Android manifest requirements for a QMOD.
 ///
 /// This intentionally exposes a small, typed surface rather than accepting raw XML. New
-/// requirement types should be added individually after defining their validation and approval
-/// policy.
+/// requirement types should be added individually after defining their validation, compatibility,
+/// and safety policy.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ManifestRequirements {

--- a/mbf-agent/src/mod_man/mod.rs
+++ b/mbf-agent/src/mod_man/mod.rs
@@ -38,7 +38,7 @@ const QMOD_SCHEMA: &str = include_str!("qmod_schema.json");
 /// NB: The schema also checks that this property is an allowed value, however it is good
 /// if we can detect a version that's too new/old manually to give a more helpful error message
 /// than "schema validation failed."
-const MAX_SCHEMA_VERSION: Version = Version::new(1, 2, 0);
+const MAX_SCHEMA_VERSION: Version = Version::new(1, 3, 0);
 
 /// A structure to manage QMODs installed on Beat Saber.
 pub struct ModManager<'cache> {
@@ -121,6 +121,78 @@ impl<'cache> ModManager<'cache> {
     /// The mod with ID `id`, or [Option::None] if no such mod existed.
     pub fn get_mod(&self, id: &str) -> Option<&Rc<RefCell<Mod>>> {
         self.mods.get(id)
+    }
+
+    /// Finds manifest requirements that would prevent `id` and its currently loaded required
+    /// dependencies from being enabled.
+    ///
+    /// Dependencies that have not been downloaded yet are checked by
+    /// [ModManager::install_mod_with_manifest] immediately after they are loaded and before their
+    /// files are copied.
+    pub fn missing_manifest_requirements(
+        &self,
+        id: &str,
+        declared_query_packages: &HashSet<String>,
+    ) -> Result<Vec<MissingManifestRequirements>> {
+        let mut visited = HashSet::new();
+        let mut missing = Vec::new();
+        self.collect_missing_manifest_requirements(
+            id,
+            declared_query_packages,
+            &mut visited,
+            &mut missing,
+        )?;
+        Ok(missing)
+    }
+
+    fn collect_missing_manifest_requirements(
+        &self,
+        id: &str,
+        declared_query_packages: &HashSet<String>,
+        visited: &mut HashSet<String>,
+        missing: &mut Vec<MissingManifestRequirements>,
+    ) -> Result<()> {
+        if !visited.insert(id.to_string()) {
+            return Ok(());
+        }
+
+        let mod_rc = self
+            .mods
+            .get(id)
+            .ok_or_else(|| anyhow!("Could not inspect mod with ID {id} as it did not exist"))?;
+        let mod_ref = mod_rc.borrow();
+
+        if let Some(requirements) = &mod_ref.manifest().manifest_requirements {
+            let query_packages = requirements.missing_query_packages(declared_query_packages);
+            if !query_packages.is_empty() {
+                missing.push(MissingManifestRequirements {
+                    mod_id: id.to_string(),
+                    query_packages,
+                });
+            }
+        }
+
+        let dependencies: Vec<String> = mod_ref
+            .manifest()
+            .dependencies
+            .iter()
+            .filter(|dependency| dependency.required)
+            .map(|dependency| dependency.id.clone())
+            .collect();
+        drop(mod_ref);
+
+        for dependency_id in dependencies {
+            if self.mods.contains_key(&dependency_id) {
+                self.collect_missing_manifest_requirements(
+                    &dependency_id,
+                    declared_query_packages,
+                    visited,
+                    missing,
+                )?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Loads the installed mods from the [paths::QMODS] directory in ModData.
@@ -220,9 +292,22 @@ impl<'cache> ModManager<'cache> {
     /// the newer version to be installed.)
     /// - `id` is not the ID of an installed mod.
     ///
-    /// This function will NOT fail if the mod is missing one of its stated mod/lib/late_mod files, but will instead
-    /// log a warning.
-    pub fn install_mod(&mut self, id: &str) -> Result<()> {
+    /// This function will NOT fail if the mod is missing one of its stated mod/lib/late_mod files,
+    /// but will instead log a warning. It will refuse to copy files for the mod or its dependencies
+    /// unless their typed manifest requirements are already present in the application manifest.
+    pub fn install_mod_with_manifest(
+        &mut self,
+        id: &str,
+        declared_query_packages: &HashSet<String>,
+    ) -> Result<()> {
+        self.install_mod_internal(id, declared_query_packages)
+    }
+
+    fn install_mod_internal(
+        &mut self,
+        id: &str,
+        declared_query_packages: &HashSet<String>,
+    ) -> Result<()> {
         // Install the mod's dependencies if applicable
         let mod_rc = self
             .mods
@@ -235,6 +320,17 @@ impl<'cache> ModManager<'cache> {
         let to_install = (*mod_rc).borrow();
         if to_install.installed() {
             return Ok(());
+        }
+
+        if let Some(requirements) = &to_install.manifest().manifest_requirements {
+            let query_packages = requirements.missing_query_packages(declared_query_packages);
+            if !query_packages.is_empty() {
+                return Err(MissingManifestRequirements {
+                    mod_id: id.to_string(),
+                    query_packages,
+                }
+                .into());
+            }
         }
 
         info!(
@@ -252,18 +348,18 @@ impl<'cache> ModManager<'cache> {
                             dep.id, dep_ref.manifest().version, dep.version_range
                         );
                         drop(dep_ref);
-                        self.install_dependency(&dep)?;
+                        self.install_dependency(dep, declared_query_packages)?;
                     } else if !dep_ref.installed() && dep.required {
                         // Must install the dependency
                         info!("Dependency {} was not installed, reinstalling", dep.id);
                         drop(dep_ref);
-                        self.install_mod(&dep.id)?;
+                        self.install_mod_internal(&dep.id, declared_query_packages)?;
                     }
                 }
                 None => {
                     if dep.required {
                         info!("Dependency {} was not found: installing now", dep.id);
-                        self.install_dependency(&dep)?;
+                        self.install_dependency(dep, declared_query_packages)?;
                     }
                 }
             }
@@ -529,8 +625,15 @@ impl<'cache> ModManager<'cache> {
             return Err(anyhow!("QMOD schema validation failed: \n{log_builder}"));
         }
 
-        Ok(serde_json::from_value(manifest_value)
-            .expect("Failed to parse as QMOD manifest, despite being valid according to schema. This is a bug"))
+        let manifest: ModInfo = serde_json::from_value(manifest_value)
+            .expect("Failed to parse as QMOD manifest, despite being valid according to schema. This is a bug");
+        if let Some(requirements) = &manifest.manifest_requirements {
+            requirements
+                .validate()
+                .context("Validating manifest requirements")?;
+        }
+
+        Ok(manifest)
     }
 
     /// Used to avoid removing library files that are still in use by another mod when uninstalling a mod.
@@ -563,7 +666,11 @@ impl<'cache> ModManager<'cache> {
         retained_libs
     }
 
-    fn install_dependency(&mut self, dep: &ModDependency) -> Result<()> {
+    fn install_dependency(
+        &mut self,
+        dep: &ModDependency,
+        declared_query_packages: &HashSet<String>,
+    ) -> Result<()> {
         // First check if we can find a copy of the dependency in the mod repo, since this is the preferred option
         // The mod repo will likely have a more up-to-date version of the dependency than the dependency downloadIfMissing
         let link = if let Some(dep_url) = self.try_get_dep_from_mod_repo(dep) {
@@ -581,7 +688,7 @@ impl<'cache> ModManager<'cache> {
                 .context("Downloading dependency")?;
 
         self.try_load_new_mod(Cursor::new(dependency_bytes))?;
-        self.install_mod(&dep.id)?;
+        self.install_mod_internal(&dep.id, declared_query_packages)?;
         Ok(())
     }
 
@@ -813,5 +920,65 @@ impl<'cache> ModManager<'cache> {
         }
 
         Ok(self.mod_repo.as_ref().expect("Just loaded mod repo"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> JSONSchema {
+        JSONSchema::options()
+            .compile(&serde_json::from_str(QMOD_SCHEMA).unwrap())
+            .unwrap()
+    }
+
+    fn valid_manifest(schema_version: &str) -> serde_json::Value {
+        serde_json::json!({
+            "_QPVersion": schema_version,
+            "name": "Manifest test",
+            "id": "manifest-test",
+            "author": "Example",
+            "version": "1.0.0",
+            "modFiles": []
+        })
+    }
+
+    #[test]
+    fn schema_keeps_existing_qmods_valid() {
+        assert!(schema().is_valid(&valid_manifest("1.2.0")));
+    }
+
+    #[test]
+    fn schema_accepts_typed_query_packages_in_version_1_3() {
+        let mut manifest = valid_manifest("1.3.0");
+        manifest["manifestRequirements"] = serde_json::json!({
+            "queryPackages": ["com.discord", "com.spotify.music"]
+        });
+
+        assert!(schema().is_valid(&manifest));
+    }
+
+    #[test]
+    fn schema_requires_version_1_3_when_manifest_requirements_are_used() {
+        let mut manifest = valid_manifest("1.2.0");
+        manifest["manifestRequirements"] = serde_json::json!({
+            "queryPackages": ["com.discord"]
+        });
+
+        assert!(!schema().is_valid(&manifest));
+    }
+
+    #[test]
+    fn schema_rejects_untyped_or_malformed_manifest_changes() {
+        for requirements in [
+            serde_json::json!({ "permissions": ["android.permission.RECORD_AUDIO"] }),
+            serde_json::json!({ "queryPackages": ["com.discord\" />"] }),
+            serde_json::json!({ "queryPackages": ["com.discord", "com.discord"] }),
+        ] {
+            let mut manifest = valid_manifest("1.3.0");
+            manifest["manifestRequirements"] = requirements;
+            assert!(!schema().is_valid(&manifest));
+        }
     }
 }

--- a/mbf-agent/src/mod_man/mod.rs
+++ b/mbf-agent/src/mod_man/mod.rs
@@ -972,6 +972,7 @@ mod tests {
     #[test]
     fn schema_rejects_untyped_or_malformed_manifest_changes() {
         for requirements in [
+            serde_json::json!({ "queryPackages": [] }),
             serde_json::json!({ "permissions": ["android.permission.RECORD_AUDIO"] }),
             serde_json::json!({ "queryPackages": ["com.discord\" />"] }),
             serde_json::json!({ "queryPackages": ["com.discord", "com.discord"] }),

--- a/mbf-agent/src/mod_man/mod.rs
+++ b/mbf-agent/src/mod_man/mod.rs
@@ -38,7 +38,7 @@ const QMOD_SCHEMA: &str = include_str!("qmod_schema.json");
 /// NB: The schema also checks that this property is an allowed value, however it is good
 /// if we can detect a version that's too new/old manually to give a more helpful error message
 /// than "schema validation failed."
-const MAX_SCHEMA_VERSION: Version = Version::new(1, 3, 0);
+const MAX_SCHEMA_VERSION: Version = Version::new(1, 2, 0);
 
 /// A structure to manage QMODs installed on Beat Saber.
 pub struct ModManager<'cache> {
@@ -162,7 +162,7 @@ impl<'cache> ModManager<'cache> {
             .ok_or_else(|| anyhow!("Could not inspect mod with ID {id} as it did not exist"))?;
         let mod_ref = mod_rc.borrow();
 
-        if let Some(requirements) = &mod_ref.manifest().manifest_requirements {
+        if let Some(requirements) = &mod_ref.manifest().mbf_manifest_requirements {
             let query_packages = requirements.missing_query_packages(declared_query_packages);
             if !query_packages.is_empty() {
                 missing.push(MissingManifestRequirements {
@@ -322,7 +322,7 @@ impl<'cache> ModManager<'cache> {
             return Ok(());
         }
 
-        if let Some(requirements) = &to_install.manifest().manifest_requirements {
+        if let Some(requirements) = &to_install.manifest().mbf_manifest_requirements {
             let query_packages = requirements.missing_query_packages(declared_query_packages);
             if !query_packages.is_empty() {
                 return Err(MissingManifestRequirements {
@@ -627,7 +627,7 @@ impl<'cache> ModManager<'cache> {
 
         let manifest: ModInfo = serde_json::from_value(manifest_value)
             .expect("Failed to parse as QMOD manifest, despite being valid according to schema. This is a bug");
-        if let Some(requirements) = &manifest.manifest_requirements {
+        if let Some(requirements) = &manifest.mbf_manifest_requirements {
             requirements
                 .validate()
                 .context("Validating manifest requirements")?;
@@ -950,23 +950,20 @@ mod tests {
     }
 
     #[test]
-    fn schema_accepts_typed_query_packages_in_version_1_3() {
-        let mut manifest = valid_manifest("1.3.0");
-        manifest["manifestRequirements"] = serde_json::json!({
-            "queryPackages": ["com.discord", "com.spotify.music"]
-        });
+    fn schema_accepts_mbf_query_packages_in_existing_qmod_versions() {
+        for version in ["0.1.2", "1.2.0"] {
+            let mut manifest = valid_manifest(version);
+            manifest["mbfManifestRequirements"] = serde_json::json!({
+                "queryPackages": ["com.discord", "com.spotify.music"]
+            });
 
-        assert!(schema().is_valid(&manifest));
+            assert!(schema().is_valid(&manifest));
+        }
     }
 
     #[test]
-    fn schema_requires_version_1_3_when_manifest_requirements_are_used() {
-        let mut manifest = valid_manifest("1.2.0");
-        manifest["manifestRequirements"] = serde_json::json!({
-            "queryPackages": ["com.discord"]
-        });
-
-        assert!(!schema().is_valid(&manifest));
+    fn schema_rejects_unstandardized_version_1_3() {
+        assert!(!schema().is_valid(&valid_manifest("1.3.0")));
     }
 
     #[test]
@@ -977,8 +974,8 @@ mod tests {
             serde_json::json!({ "queryPackages": ["com.discord\" />"] }),
             serde_json::json!({ "queryPackages": ["com.discord", "com.discord"] }),
         ] {
-            let mut manifest = valid_manifest("1.3.0");
-            manifest["manifestRequirements"] = requirements;
+            let mut manifest = valid_manifest("0.1.2");
+            manifest["mbfManifestRequirements"] = requirements;
             assert!(!schema().is_valid(&manifest));
         }
     }

--- a/mbf-agent/src/mod_man/qmod_schema.json
+++ b/mbf-agent/src/mod_man/qmod_schema.json
@@ -5,7 +5,7 @@
   "description": "A mod of the format described by QuestPatcher.",
   "examples": [
     {
-      "_QPVersion": "1.2.0",
+      "_QPVersion": "1.3.0",
       "name": "ExampleMod2",
       "id": "example-mod-2",
       "author": "Lauriethefish#6700",
@@ -13,6 +13,11 @@
       "packageId": "com.AnotherAxiom.GorillaTag",
       "packageVersion": "1.0.1",
       "isLibrary": false,
+      "manifestRequirements": {
+        "queryPackages": [
+          "com.discord"
+        ]
+      },
       "modFiles": [
         "libexample-mod-2.so"
       ],
@@ -54,6 +59,16 @@
     { "required": [ "dependencies" ] },
     { "required": [ "fileCopies" ] }
   ],
+  "allOf": [
+    {
+      "if": { "required": [ "manifestRequirements" ] },
+      "then": {
+        "properties": {
+          "_QPVersion": { "const": "1.3.0" }
+        }
+      }
+    }
+  ],
   "title": "The root schema",
   "type": "object",
   "properties": {
@@ -65,10 +80,11 @@
         "0.1.2",
         "1.0.0",
         "1.1.0",
-        "1.2.0"
+        "1.2.0",
+        "1.3.0"
       ],
       "default": "",
-      "description": "The version of the schema to use for QuestPatcher. Must be 0.1.0, 0.1.1, 0.1.2, 1.0.0, 1.1.0 or 1.2.0",
+      "description": "The version of the schema to use for QuestPatcher. Manifest requirements require 1.3.0; older QMODs remain supported.",
       "examples": [
         "1.2.0"
       ],
@@ -180,6 +196,31 @@
       ],
       "title": "Modloader",
       "type": "string"
+    },
+    "manifestRequirements": {
+      "$id": "#/properties/manifestRequirements",
+      "type": "object",
+      "title": "Android Manifest Requirements",
+      "description": "Typed Android manifest declarations that must exist before the mod can be enabled.",
+      "required": [
+        "queryPackages"
+      ],
+      "properties": {
+        "queryPackages": {
+          "$id": "#/properties/manifestRequirements/properties/queryPackages",
+          "type": "array",
+          "title": "Visible packages",
+          "description": "Android package IDs to add as package children of the manifest queries element.",
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "maxLength": 255,
+            "pattern": "^[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z][A-Za-z0-9_]*)+$"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "modFiles": {
       "$id": "#/properties/modFiles",

--- a/mbf-agent/src/mod_man/qmod_schema.json
+++ b/mbf-agent/src/mod_man/qmod_schema.json
@@ -5,7 +5,7 @@
   "description": "A mod of the format described by QuestPatcher.",
   "examples": [
     {
-      "_QPVersion": "1.3.0",
+      "_QPVersion": "0.1.2",
       "name": "ExampleMod2",
       "id": "example-mod-2",
       "author": "Lauriethefish#6700",
@@ -13,7 +13,7 @@
       "packageId": "com.AnotherAxiom.GorillaTag",
       "packageVersion": "1.0.1",
       "isLibrary": false,
-      "manifestRequirements": {
+      "mbfManifestRequirements": {
         "queryPackages": [
           "com.discord"
         ]
@@ -59,16 +59,6 @@
     { "required": [ "dependencies" ] },
     { "required": [ "fileCopies" ] }
   ],
-  "allOf": [
-    {
-      "if": { "required": [ "manifestRequirements" ] },
-      "then": {
-        "properties": {
-          "_QPVersion": { "const": "1.3.0" }
-        }
-      }
-    }
-  ],
   "title": "The root schema",
   "type": "object",
   "properties": {
@@ -80,11 +70,10 @@
         "0.1.2",
         "1.0.0",
         "1.1.0",
-        "1.2.0",
-        "1.3.0"
+        "1.2.0"
       ],
       "default": "",
-      "description": "The version of the schema to use for QuestPatcher. Manifest requirements require 1.3.0; older QMODs remain supported.",
+      "description": "The version of the schema to use for QuestPatcher.",
       "examples": [
         "1.2.0"
       ],
@@ -197,17 +186,17 @@
       "title": "Modloader",
       "type": "string"
     },
-    "manifestRequirements": {
-      "$id": "#/properties/manifestRequirements",
+    "mbfManifestRequirements": {
+      "$id": "#/properties/mbfManifestRequirements",
       "type": "object",
-      "title": "Android Manifest Requirements",
-      "description": "Typed Android manifest declarations that must exist before the mod can be enabled.",
+      "title": "MBF Android Manifest Requirements",
+      "description": "Optional MBF-specific typed Android manifest declarations that must exist before the mod can be enabled.",
       "required": [
         "queryPackages"
       ],
       "properties": {
         "queryPackages": {
-          "$id": "#/properties/manifestRequirements/properties/queryPackages",
+          "$id": "#/properties/mbfManifestRequirements/properties/queryPackages",
           "type": "array",
           "title": "Visible packages",
           "description": "Android package IDs to add as package children of the manifest queries element.",

--- a/mbf-agent/src/mod_man/qmod_schema.json
+++ b/mbf-agent/src/mod_man/qmod_schema.json
@@ -211,6 +211,7 @@
           "type": "array",
           "title": "Visible packages",
           "description": "Android package IDs to add as package children of the manifest queries element.",
+          "minItems": 1,
           "maxItems": 32,
           "uniqueItems": true,
           "items": {

--- a/mbf-agent/src/models/response.rs
+++ b/mbf-agent/src/models/response.rs
@@ -1,5 +1,7 @@
 //! Models used for communication *from the backend back to the frontend*
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::mod_man;
@@ -10,6 +12,8 @@ pub struct AppInfo {
     pub obb_present: bool,
     #[serde(skip_serializing)]
     pub path: String,
+    #[serde(skip_serializing)]
+    pub query_packages: HashSet<String>,
     pub version: String,
     pub manifest_xml: String,
 }
@@ -86,6 +90,13 @@ pub struct ModModel {
     pub is_core: bool,
 }
 
+/// A typed manifest requirement that prevented a mod from being enabled.
+#[derive(Serialize)]
+pub struct MissingManifestRequirementModel {
+    pub mod_id: String,
+    pub query_packages: Vec<String>,
+}
+
 impl From<&mod_man::Mod> for ModModel {
     fn from(value: &mod_man::Mod) -> Self {
         Self {
@@ -125,6 +136,8 @@ pub enum Response {
         // If any of the mods failed to install/uninstall, this will be Some with a string
         // containing a list of the errors generated.
         failures: Option<String>,
+        // Requirements that must be approved and applied before retrying this operation.
+        manifest_changes_required: Vec<MissingManifestRequirementModel>,
     },
     Patched {
         installed_mods: Vec<ModModel>,

--- a/mbf-agent/src/models/response.rs
+++ b/mbf-agent/src/models/response.rs
@@ -136,7 +136,7 @@ pub enum Response {
         // If any of the mods failed to install/uninstall, this will be Some with a string
         // containing a list of the errors generated.
         failures: Option<String>,
-        // Requirements that must be approved and applied before retrying this operation.
+        // Requirements that must be applied before retrying this operation.
         manifest_changes_required: Vec<MissingManifestRequirementModel>,
     },
     Patched {

--- a/mbf-agent/src/patching.rs
+++ b/mbf-agent/src/patching.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::OsStr, fs::{File, OpenOptions}, io::{Cursor, Read, Write}, path::{Path, PathBuf}, process::Command
+    ffi::OsStr, fs::{File, OpenOptions}, io::{Cursor, Read, Write}, path::{Path, PathBuf}, process::{Command, Output}
 };
 
 use crate::{
@@ -159,7 +159,7 @@ fn patch_and_reinstall(
         }
     }
 
-    reinstall_modded_app(&temp_apk_path).context("Reinstalling modded APK")?;
+    reinstall_modded_app(&temp_apk_path, manifest_only).context("Reinstalling modded APK")?;
     std::fs::remove_file(temp_apk_path)?;
 
     info!("Restoring OBB files");
@@ -189,34 +189,36 @@ pub fn backup_player_data() -> Result<()> {
     Ok(())
 }
 
-fn reinstall_modded_app(
-    temp_apk_path: &Path
-) -> Result<()> {
+fn reinstall_modded_app(temp_apk_path: &Path, replace_existing: bool) -> Result<()> {
     info!("Reinstalling modded app");
-    Command::new("pm")
-        .args(["uninstall", &PARAMETERS.apk_id])
-        .output()
-        .context("Uninstalling vanilla APK")?;
+    if !replace_existing {
+        let uninstall_output = Command::new("pm")
+            .args(["uninstall", &PARAMETERS.apk_id])
+            .output()
+            .context("Invoking package manager to uninstall vanilla APK")?;
+        ensure_pm_succeeded(uninstall_output, "uninstalling vanilla APK")?;
+    }
 
     let is_pico = get_android_device_manufacturer()
         .map(|v| v.to_lowercase().contains("pico"))
         .unwrap_or(false);
 
-    if is_pico {
-        Command::new("pm")
-            .args([
-                "install", 
-                "-i", "com.picovr.store", // needed to display game icon in the app launcher
-                &temp_apk_path.to_string_lossy()
-            ])
-            .output()
-            .context("Installing modded APK")?;
-    } else {
-        Command::new("pm")
-            .args(["install", &temp_apk_path.to_string_lossy()])
-            .output()
-            .context("Installing modded APK")?;
+    let mut install_command = Command::new("pm");
+    install_command.arg("install");
+    if replace_existing {
+        // Manifest-only repatches are signed with the same MBF certificate. Android package
+        // updates are transactional, so a rejected APK leaves the existing game installed.
+        install_command.arg("-r");
     }
+    if is_pico {
+        // Needed to display the game icon in the Pico app launcher.
+        install_command.args(["-i", "com.picovr.store"]);
+    }
+    let install_output = install_command
+        .arg(temp_apk_path)
+        .output()
+        .context("Invoking package manager to install modded APK")?;
+    ensure_pm_succeeded(install_output, "installing modded APK")?;
 
     info!("Granting external storage permission");
     Command::new("appops")
@@ -233,6 +235,21 @@ fn reinstall_modded_app(
         Command::new("pm")
             .args(["grant", &PARAMETERS.apk_id, "android.permission.READ_EXTERNAL_STORAGE"])
             .output()?;    
+    }
+
+    Ok(())
+}
+
+fn ensure_pm_succeeded(output: Output, action: &str) -> Result<()> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let reported_success = stdout.lines().any(|line| line.trim() == "Success");
+    if !output.status.success() || !reported_success {
+        anyhow::bail!(
+            "Package manager failed while {action}. stdout: `{}`, stderr: `{}`",
+            stdout.trim(),
+            stderr.trim()
+        );
     }
 
     Ok(())

--- a/mbf-site/src/Agent.ts
+++ b/mbf-site/src/Agent.ts
@@ -391,11 +391,11 @@ export async function patchApp(device: Adb,
           manifest_xml: manifestMod,
           obb_present: beforePatch.app_info!.obb_present
       },
-      core_mods: {
-          core_mod_install_status: "Ready",
-          supported_versions: beforePatch.core_mods!.supported_versions,
-          downgrade_versions: [],
-          is_awaiting_diff: false
+      core_mods: beforePatch.core_mods === null ? null : {
+        core_mod_install_status: "Ready",
+        supported_versions: beforePatch.core_mods.supported_versions,
+        downgrade_versions: [],
+        is_awaiting_diff: false
       },
       modloader_install_status: "Ready",
       installed_mods: response.installed_mods

--- a/mbf-site/src/AndroidManifest.ts
+++ b/mbf-site/src/AndroidManifest.ts
@@ -6,6 +6,7 @@ const ANDROID_NS_URI: string = "http://schemas.android.com/apk/res/android";
 export class AndroidManifest {
     private features: string[] = [];
     private permissions: string[] = [];
+    private queryPackages: string[] = [];
     private nativeLibraries: string[] = [];
     private metadata: { [name: string]: string } = {};
     private document!: XMLDocument;
@@ -42,6 +43,7 @@ export class AndroidManifest {
         this.applicationEl = this.document.getElementsByTagName("application")[0];
         this.permissions = [];
         this.features = [];
+        this.queryPackages = [];
         // Load the permissions and features already within the manifest.
         Array.from(this.document.getElementsByTagName("uses-permission")).forEach(permNode => {
             const permName = permNode.getAttribute(`${androidNsPrefix}:name`);
@@ -55,6 +57,16 @@ export class AndroidManifest {
                 this.features.push(featName);
             }
         })
+        Array.from(this.manifestEl.childNodes)
+            .filter(node => node.nodeType === Node.ELEMENT_NODE && node.nodeName === "queries")
+            .flatMap(node => Array.from(node.childNodes))
+            .filter(node => node.nodeType === Node.ELEMENT_NODE && node.nodeName === "package")
+            .forEach(packageNode => {
+                const packageName = (packageNode as Element).getAttributeNS(ANDROID_NS_URI, "name");
+                if(packageName !== null && !this.queryPackages.includes(packageName)) {
+                    this.queryPackages.push(packageName);
+                }
+            });
         Array.from(this.document.getElementsByTagName("uses-native-library")).forEach(libNode => {
             const libName = libNode.getAttribute(`${androidNsPrefix}:name`);
             if(libName !== null) {
@@ -94,6 +106,11 @@ export class AndroidManifest {
     // Gets an array of the current features within the APK.
     public getFeatures(): string[] {
         return this.features;
+    }
+
+    // Gets package IDs declared directly beneath the manifest's <queries> element.
+    public getQueryPackages(): string[] {
+        return this.queryPackages;
     }
 
     // Gets a map of metadata element names to metadata values within the application element of the manifest.
@@ -136,6 +153,32 @@ export class AndroidManifest {
         permissionElement.setAttributeNS(ANDROID_NS_URI, `${this.androidNsPrefix}:name`, perm);
         this.manifestEl.appendChild(permissionElement);
         this.permissions.push(perm);
+    }
+
+    // Adds a package visibility declaration. This does not grant the app a permission; it only
+    // allows PackageManager APIs to discover the named package on Android 11 and newer.
+    public addQueryPackage(packageName: string) {
+        if(this.queryPackages.includes(packageName)) {
+            return;
+        }
+
+        let queriesElement = Array.from(this.manifestEl.childNodes)
+            .find(node => node.nodeType === Node.ELEMENT_NODE && node.nodeName === "queries") as Element | undefined;
+        if(queriesElement === undefined) {
+            queriesElement = this.document.createElement("queries");
+            // Keeping <queries> before <application> matches Android's documented examples and
+            // avoids disturbing the application's existing children.
+            this.manifestEl.insertBefore(queriesElement, this.applicationEl);
+        }
+
+        const packageElement = this.document.createElement("package");
+        packageElement.setAttributeNS(
+            ANDROID_NS_URI,
+            `${this.androidNsPrefix}:name`,
+            packageName
+        );
+        queriesElement.appendChild(packageElement);
+        this.queryPackages.push(packageName);
     }
 
     // Adds a <uses-feature> element for the specified feature underneath the manifest tag.

--- a/mbf-site/src/Messages.ts
+++ b/mbf-site/src/Messages.ts
@@ -77,7 +77,14 @@ export interface Mods {
 export interface ModSyncResult {
     type: 'ModSyncResult',
     installed_mods: Mod[],
-    failures: string | null
+    failures: string | null,
+    // Optional so a new frontend remains compatible with an older cached agent.
+    manifest_changes_required?: MissingManifestRequirement[]
+}
+
+export interface MissingManifestRequirement {
+    mod_id: string,
+    query_packages: string[]
 }
 
 export interface Patched {

--- a/mbf-site/src/components/ModManager.tsx
+++ b/mbf-site/src/components/ModManager.tsx
@@ -6,10 +6,10 @@ import { ModCard } from "./ModCard";
 import UploadIcon from '../icons/upload.svg';
 import ToolsIcon from '../icons/tools-icon.svg';
 import '../css/ModManager.css';
-import { importFile, importUrl, removeMod, setModStatuses } from "../Agent";
+import { importFile, importUrl, patchApp, removeMod, setModStatuses } from "../Agent";
 import { toast } from "react-toastify";
 import { ModRepoBrowser } from "./ModRepoBrowser";
-import { ImportResult, ImportedMod, ModStatus } from "../Messages";
+import { ImportResult, ImportedMod, MissingManifestRequirement, ModStatus, ModSyncResult } from "../Messages";
 import { OptionsMenu } from "./OptionsMenu";
 import useFileDropper from "../hooks/useFileDropper";
 import { Log } from "../Logging";
@@ -17,6 +17,7 @@ import { useSetWorking, useSyncStore, wrapOperation } from "../SyncStore";
 import { ModRepoMod } from "../ModsRepo";
 import { useDeviceStore } from "../DeviceStore";
 import SyncIcon from "../icons/sync.svg"
+import { AndroidManifest } from "../AndroidManifest";
 
 
 interface ModManagerProps {
@@ -48,6 +49,8 @@ export function ModManager(props: ModManagerProps) {
             mods={mods}
             setMods={setMods}
             gameVersion={gameVersion}
+            modStatus={modStatus}
+            setModStatus={setModStatus}
             visible={menu === SelectedMenu.add}
         />
         
@@ -55,6 +58,8 @@ export function ModManager(props: ModManagerProps) {
             mods={mods}
             setMods={setMods}
             gameVersion={gameVersion}
+            modStatus={modStatus}
+            setModStatus={setModStatus}
             visible={menu === SelectedMenu.current}
         />
         
@@ -95,30 +100,39 @@ interface ModMenuProps {
     mods: Mod[],
     setMods: (mods: Mod[]) => void,
     gameVersion: string,
+    modStatus: ModStatus,
+    setModStatus: (status: ModStatus) => void,
     visible?: boolean
 }
 
 function InstalledModsMenu(props: ModMenuProps) {
     const { mods,
         setMods,
-        gameVersion
+        gameVersion,
+        modStatus,
+        setModStatus
     } = props;
-    const { device } = useDeviceStore((state) => ({ device: state.device }));
+    const { device, devicePreV51 } = useDeviceStore((state) => ({
+        device: state.device,
+        devicePreV51: state.devicePreV51
+    }));
     const [changes, setChanges] = useState({} as { [id: string]: boolean });
 
 
     return <div className={`installedModsMenu fadeIn ${props.visible ? "" : "hidden"}`}>
         {Object.keys(changes).length > 0 && <button className={`syncChanges fadeIn ${props.visible ? "" : "hidden"}`} onClick={async () => {
             if (!device) return;
-            setChanges({});
             Log.debug("Installing mods, statuses requested: " + JSON.stringify(changes));
             await wrapOperation("Syncing mods", "Failed to sync mods", async () => {
-                const modSyncResult = await setModStatuses(device, changes);
+                const modSyncResult = await setModStatusesWithManifestRequirements(
+                    device,
+                    devicePreV51,
+                    changes,
+                    modStatus,
+                    setModStatus
+                );
                 setMods(modSyncResult.installed_mods);
-
-                if(modSyncResult.failures !== null) {
-                    throw modSyncResult.failures;
-                }
+                setChanges({});
             });
 
         }}>
@@ -211,9 +225,14 @@ function AddModsMenu(props: ModMenuProps) {
     const {
         mods,
         setMods,
-        gameVersion
+        gameVersion,
+        modStatus,
+        setModStatus
     } = props;
-    const { device } = useDeviceStore((state) => ({ device: state.device }));
+    const { device, devicePreV51 } = useDeviceStore((state) => ({
+        device: state.device,
+        devicePreV51: state.devicePreV51
+    }));
 
     // Automatically installs a mod when it is imported, or warns the user if it isn't designed for the current game version.
     // Gives appropriate toasts/reports errors in each case.
@@ -231,15 +250,15 @@ function AddModsMenu(props: ModMenuProps) {
                 + trimGameVersion(gameVersion) + ".", { autoClose: false });
         }   else    {
             try {
-                const result = await setModStatuses(device, { [imported_id]: true });
+                const result = await setModStatusesWithManifestRequirements(
+                    device,
+                    devicePreV51,
+                    { [imported_id]: true },
+                    modStatus,
+                    setModStatus
+                );
                 setMods(result.installed_mods);
-
-                // This is where typical mod install failures occur
-                if (result.failures !== null) {
-                    toast.error(result.failures, { autoClose: false });
-                }   else    {
-                    toast.success("Successfully downloaded and installed " + imported_mod.name + " v" + imported_mod.version)
-                }
+                toast.success("Successfully downloaded and installed " + imported_mod.name + " v" + imported_mod.version)
 
             }   catch(err) {
                 // If this occurs, it's a panic i.e. bug in the agent
@@ -370,6 +389,86 @@ function AddModsMenu(props: ModMenuProps) {
             enqueueImports(modRepoImports);
         }} />
     </div>
+}
+
+const MAX_MANIFEST_REPATCH_ATTEMPTS = 16;
+
+// Enables/disables mods, pausing to show and apply any typed manifest requirements returned by
+// the agent. A newly downloaded dependency can introduce another requirement, so the operation is
+// retried after each successful repatch. The bounded loop prevents a malformed dependency graph
+// from causing an endless cycle.
+async function setModStatusesWithManifestRequirements(
+    device: Adb,
+    devicePreV51: boolean,
+    changes: { [id: string]: boolean },
+    initialStatus: ModStatus,
+    setModStatus: (status: ModStatus) => void
+): Promise<ModSyncResult> {
+    let currentStatus = initialStatus;
+
+    for(let attempt = 0; attempt < MAX_MANIFEST_REPATCH_ATTEMPTS; attempt++) {
+        const result = await setModStatuses(device, changes);
+        if(result.failures !== null) {
+            throw result.failures;
+        }
+
+        const requirements = result.manifest_changes_required ?? [];
+        if(requirements.length === 0) {
+            return result;
+        }
+
+        if(currentStatus.app_info === null) {
+            throw new Error("Cannot apply manifest requirements because Beat Saber is not installed.");
+        }
+
+        if(!confirmManifestRequirements(requirements)) {
+            throw new Error("The requested manifest changes were not approved; no requesting mod was enabled.");
+        }
+
+        const manifest = new AndroidManifest(currentStatus.app_info.manifest_xml);
+        const packagesBefore = new Set(manifest.getQueryPackages());
+        requirements
+            .flatMap(requirement => requirement.query_packages)
+            .forEach(packageName => manifest.addQueryPackage(packageName));
+
+        // If the device already contains every declaration, retry without needlessly rebuilding
+        // the APK. This also protects against a stale frontend status object.
+        if(manifest.getQueryPackages().every(packageName => packagesBefore.has(packageName))) {
+            continue;
+        }
+
+        const repatchedStatus = await patchApp(
+            device,
+            currentStatus,
+            null,
+            manifest.toString(),
+            true,
+            false,
+            devicePreV51,
+            null
+        );
+        // The existing repatch response does not reload the mod directory. Preserve the agent's
+        // preflight result until the final SetModsEnabled response supplies the authoritative list.
+        repatchedStatus.installed_mods = result.installed_mods;
+        currentStatus = repatchedStatus;
+        setModStatus(repatchedStatus);
+    }
+
+    throw new Error(
+        `More than ${MAX_MANIFEST_REPATCH_ATTEMPTS} manifest repatches were requested while resolving dependencies.`
+    );
+}
+
+function confirmManifestRequirements(requirements: MissingManifestRequirement[]): boolean {
+    const descriptions = requirements.map(requirement =>
+        `- ${requirement.mod_id}: ${requirement.query_packages.join(", ")}`
+    );
+
+    return window.confirm(
+        "The following mods need Beat Saber's manifest to make specific installed apps visible:\n\n"
+        + descriptions.join("\n")
+        + "\n\nThis does not grant Android permissions. MBF will repatch the game before enabling these mods. Continue?"
+    );
 }
 
 

--- a/mbf-site/src/components/ModManager.tsx
+++ b/mbf-site/src/components/ModManager.tsx
@@ -261,8 +261,7 @@ function AddModsMenu(props: ModMenuProps) {
                 toast.success("Successfully downloaded and installed " + imported_mod.name + " v" + imported_mod.version)
 
             }   catch(err) {
-                // If this occurs, it's a panic i.e. bug in the agent
-                toast.error(`Failed to install ${imported_id} after importing due to an internal error: ${err}`, { autoClose: false} );
+                toast.error(`Failed to install ${imported_id} after importing: ${err}`, { autoClose: false} );
             }
         }
     }
@@ -423,17 +422,13 @@ async function setModStatusesWithManifestRequirements(
         }
 
         const manifest = new AndroidManifest(currentStatus.app_info.manifest_xml);
-        const packagesBefore = new Set(manifest.getQueryPackages());
         requirements
             .flatMap(requirement => requirement.query_packages)
             .forEach(packageName => manifest.addQueryPackage(packageName));
 
-        // If the device already contains every declaration, retry without needlessly rebuilding
-        // the APK. This also protects against a stale frontend status object.
-        if(manifest.getQueryPackages().every(packageName => packagesBefore.has(packageName))) {
-            continue;
-        }
-
+        // Always perform the requested repatch, even if the frontend's cached XML already contains
+        // every package. The agent made this decision from the installed binary manifest; skipping
+        // here would leave a stale frontend status unable to repair the actual APK.
         const repatchedStatus = await patchApp(
             device,
             currentStatus,

--- a/mbf-site/src/components/ModManager.tsx
+++ b/mbf-site/src/components/ModManager.tsx
@@ -9,7 +9,7 @@ import '../css/ModManager.css';
 import { importFile, importUrl, patchApp, removeMod, setModStatuses } from "../Agent";
 import { toast } from "react-toastify";
 import { ModRepoBrowser } from "./ModRepoBrowser";
-import { ImportResult, ImportedMod, MissingManifestRequirement, ModStatus, ModSyncResult } from "../Messages";
+import { ImportResult, ImportedMod, ModStatus, ModSyncResult } from "../Messages";
 import { OptionsMenu } from "./OptionsMenu";
 import useFileDropper from "../hooks/useFileDropper";
 import { Log } from "../Logging";
@@ -393,10 +393,11 @@ function AddModsMenu(props: ModMenuProps) {
 
 const MAX_MANIFEST_REPATCH_ATTEMPTS = 16;
 
-// Enables/disables mods, pausing to show and apply any typed manifest requirements returned by
-// the agent. A newly downloaded dependency can introduce another requirement, so the operation is
-// retried after each successful repatch. The bounded loop prevents a malformed dependency graph
-// from causing an endless cycle.
+// Enables/disables mods, automatically applying any typed manifest requirements returned by the
+// agent. The agent only accepts the deliberately narrow, validated package-visibility model; raw
+// XML and permissions never reach this path. A newly downloaded dependency can introduce another
+// requirement, so the operation is retried after each successful repatch. The bounded loop
+// prevents a malformed dependency graph from causing an endless cycle.
 async function setModStatusesWithManifestRequirements(
     device: Adb,
     devicePreV51: boolean,
@@ -419,10 +420,6 @@ async function setModStatusesWithManifestRequirements(
 
         if(currentStatus.app_info === null) {
             throw new Error("Cannot apply manifest requirements because Beat Saber is not installed.");
-        }
-
-        if(!confirmManifestRequirements(requirements)) {
-            throw new Error("The requested manifest changes were not approved; no requesting mod was enabled.");
         }
 
         const manifest = new AndroidManifest(currentStatus.app_info.manifest_xml);
@@ -456,18 +453,6 @@ async function setModStatusesWithManifestRequirements(
 
     throw new Error(
         `More than ${MAX_MANIFEST_REPATCH_ATTEMPTS} manifest repatches were requested while resolving dependencies.`
-    );
-}
-
-function confirmManifestRequirements(requirements: MissingManifestRequirement[]): boolean {
-    const descriptions = requirements.map(requirement =>
-        `- ${requirement.mod_id}: ${requirement.query_packages.join(", ")}`
-    );
-
-    return window.confirm(
-        "The following mods need Beat Saber's manifest to make specific installed apps visible:\n\n"
-        + descriptions.join("\n")
-        + "\n\nThis does not grant Android permissions. MBF will repatch the game before enabling these mods. Continue?"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR lets a QMOD tell MBF that a specific Android package must be visible to the modded game.
[Meta Quest system software v51](https://communityforums.atmeta.com/blog/AnnouncementsBlog/ptc-v51-release-megathread-quest-2-and-quest-pro/1038807),
now part of Meta Horizon OS, moved Quest directly from Android 10 to Android 12. It was therefore the
first Quest OS release where Android's
[package-visibility filtering](https://developer.android.com/training/package-visibility) could
affect apps targeting API level 30 or newer. The initial supported use case is Discord Rich Presence,
which needs Beat Saber to be able to find the installed Discord app.

A mod declares the requirement in `mod.json`:

```json
"mbfManifestRequirements": {
  "queryPackages": ["com.discord"]
}
```

When the package is missing from the installed manifest, MBF adds:

```xml
<queries>
    <package android:name="com.discord" />
</queries>
```

If the entry is missing, MBF adds it to Beat Saber's manifest, installs the updated APK over the
existing game, and then continues installing the mod.

## Why this is an MBF extension

The field is optional and deliberately named `mbfManifestRequirements`. It does not introduce a new
shared QMOD version or claim support from every QMOD installer.

That keeps this change limited to MBF and the mod that currently needs it. Existing QMODs are
unaffected, and QMODs using the extension retain their existing `_QPVersion`. Installers that do not
recognize the additional root property can ignore it. Mods relying on the declaration should still
detect an unavailable package or service at runtime and show an actionable message, which covers
older MBF releases and other installers.

## How it works

- MBF reads requirements from enabled user QMODs and their required dependencies.
- The installed binary Android manifest is treated as authoritative.
- If a required package declaration is missing, the agent returns the requesting mod and package
  IDs before copying the mod's files.
- The frontend performs a manifest-only repatch and retries the enable operation automatically.
- The retry is bounded, and the agent checks the installed manifest again before enabling the mod.
- Package declarations are additive and are not duplicated when they already exist.

## Safety and compatibility

This is intentionally a narrow typed interface rather than a general manifest editor.

- A QMOD may request between 1 and 32 unique package IDs.
- Package IDs are limited to 255 ASCII characters. Each dot-separated component must begin with a
  letter and may otherwise contain only letters, digits, or underscores.
- JSON Schema and the Rust agent independently enforce the same constraints.
- Raw XML and arbitrary insertion points are not accepted.
- QMODs cannot request permissions, including `QUERY_ALL_PACKAGES`, dangerous/runtime permissions,
  or special permissions.
- Activities, services, receivers, providers, features, metadata, attributes, and other manifest
  changes are outside this interface.
- Manifest-only installs use `pm install -r` and require both a successful process result and
  Android's `Success` response. A rejected replacement does not first uninstall the working game.

Package declarations are not removed when a mod is disabled or uninstalled. MBF does not currently
track whether a declaration came from the original game, was added by MBF, or is shared by multiple
mods. Safe removal would require persistent provenance and reference counting.

## QPM packaging support

QPM.CLI 1.5.11 currently drops unknown root properties while generating `mod.json`. Discord Rich
Presence therefore adds `mbfManifestRequirements` after `qpm qmod zip`. Its post-build tool rewrites
the archive atomically, verifies the final field, preserves archive ordering, and confirms that every
non-manifest payload is unchanged. The mod's build and release workflows both test and verify this
step.

This affects mod authors producing a QMOD; it does not affect users installing the completed
archive. The finished QMOD already contains the field that MBF reads.

First-class QPM support can be added separately without changing this MBF interface:

1. [QPM.qmod](https://github.com/QuestPackageManager/QPM.Qmod) would preserve namespaced root
   extensions such as `mbfManifestRequirements`, either as an optional typed field or through a
   generic extension map.
2. QPM.CLI would update its QPM.qmod dependency and lockfile.
3. QPM.CLI would add round-trip tests for `qmod manifest`, `qmod zip`, and `qmod zip --import`, then
   publish a release containing that support.
4. Mod projects could remove their post-build injection step after adopting that release.

Those producer-tooling changes are not required for MBF to install an already-correct QMOD and are
not part of this PR.

## Initial scope

This implementation covers user-installed QMODs enabled through `SetModsEnabled`, including
required dependencies found or downloaded during that operation.

Initial core-mod bootstrap and Quick Fix install core QMODs inside the patch request and do not use
the same structured retry response. Supporting manifest requirements from the core-mod resource
index would need a separate metadata contract and is outside this PR.

## Validation

- `cargo test -p mbf-agent`: 16 tests passed.
- `pnpm@9.5.0 --dir mbf-site build`: TypeScript and Vite production build passed.
- `cargo build -p mbf-agent --target aarch64-linux-android --release`: passed.
- Discord Rich Presence post-build injector tests: 4 tests passed.
- A clean WSL/QPM 1.5.11 build completed dependency restoration, helper and native builds, QMOD
  creation, manifest injection, and final archive verification.
- The resulting QMOD retained `_QPVersion: 0.1.2`, contained only the requested `com.discord`
  requirement, and produced an identical archive when the injector was run a second time.
- On a Quest 2 running Beat Saber `1.40.8_7379`, MBF installed and enabled Discord Rich Presence
  v0.3.0, automatically repatched the game, and read back exactly one direct
  `/manifest/queries/package` declaration for `com.discord`.
- Beat Saber continued to run and work as expected after the manifest update. Existing mods and
  maps remained available, and Discord Rich Presence sent live game data to Discord.

## Documentation and related work

The new `docs/qmod-manifest-requirements.md` document explains the field, validation rules,
compatibility behavior, security boundary, current QPM packaging step, future native QPM support,
core-mod limitation, and additive-removal policy.

The tested consumer implementation is available in the
[Discord Rich Presence companion commit](https://github.com/Loud160/BSQ_DiscordRichPresence/commit/3e0cef8fc64c2219a1bd2266abe933c388349fc4).